### PR TITLE
Use S3 to speed up census data

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,14 +5,14 @@ before_install:
 - npm install -g csvtojson mapshaper geojson-polygon-labels
 script:
 - make deploy
-# deploy:
-#   skip_cleanup: true
-#   provider: s3
-#   access_key_id: $AWS_KEY
-#   secret_access_key: $AWS_SECRET
-#   bucket: eviction-lab-tilesets
-#   acl: public_read
-#   detect_encoding: true
-#   local_dir: tilesets
-#   on:
-#     repo: EvictionLab/eviction-lab-etl
+deploy:
+  skip_cleanup: true
+  provider: s3
+  access_key_id: $AWS_KEY
+  secret_access_key: $AWS_SECRET
+  bucket: eviction-lab-data
+  acl: public_read
+  detect_encoding: true
+  local_dir: tilesets
+  on:
+    repo: EvictionLab/eviction-lab-etl

--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ brew install tippecanoe
 
 To create any individual file (described in the `Makefile`) enter `make` and its name. Otherwise, to generate the full set of files, run `make all`.
 
+## Build Census Data from Source
+
+Currently the Census GeoJSON is getting pulled from an S3 bucket where it has been pre-processed and gzipped. If you want to build this from the original Census files, run `make -f census.mk all` before running `make all`. It will create the initial GeoJSON files, and because Make uses file existence to determine dependencies you can then run `make all` and any other steps as normal.
+
 ## View Tiles Locally
 
 With Docker installed, run:

--- a/census.mk
+++ b/census.mk
@@ -1,0 +1,24 @@
+## Makefile for creating Census data from source rather than S3
+census_ftp_base = ftp://ftp2.census.gov/geo/tiger/GENZ2016/shp/
+
+block-groups-pattern = cb_2016_*_bg_500k.zip
+tracts-pattern = cb_2016_*_tract_500k.zip
+cities-pattern = cb_2016_*_place_500k.zip
+counties-pattern = cb_2016_us_county_500k.zip
+states-pattern = cb_2016_us_state_500k.zip
+zip-codes-pattern = cb_2016_us_zcta510_500k.zip
+
+geo_types = states counties zip-codes cities tracts block-groups
+
+.PHONY: all
+
+all: $(foreach t, $(geo_types), census/$(t).geojson)
+
+## Census GeoJSON
+census/%.geojson:
+	mkdir -p census/$*
+	wget -np -nd -r -P census/$* -A '$($*-pattern)' $(census_ftp_base)
+	for f in ./census/$*/*.zip; do unzip -d ./census/$* $$f; done
+	mapshaper ./census/$*/*.shp combine-files \
+		-each "this.properties.GEOID = '000' + this.properties.GEOID10" where="this.properties.GEOID10" \
+		-o $@ combine-layers format=geojson


### PR DESCRIPTION
Fixes #1. I didn't realize LFS had such a strict quota, but this should get around it, and with the data gzipped it doesn't take too long to download. We'll see how Travis builds go though (currently I'm using a new test bucket I created, but we can point it at the tileset bucket once we know it's working)