### PR TITLE
Use tilesets S3 bucket for deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ deploy:
   provider: s3
   access_key_id: $AWS_KEY
   secret_access_key: $AWS_SECRET
-  bucket: eviction-lab-data
+  bucket: eviction-lab-tilesets
   acl: public_read
   detect_encoding: true
   local_dir: tilesets


### PR DESCRIPTION
Since the tileset names don't overlap and the deployment to `eviction-lab-data` worked I'm switching it over to the `eviction-lab-tilesets` bucket