### PR TITLE
Refactor workflow, data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@ data_tiles
 json
 tiles
 tilesets
-year_data
-census_year_data
+grouped_data
 .vscode
 .DS_Store

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ tracts-row = print "\"" $$2 "\"," $$1 "," $$3 "," substr($$4, 2) ",\"" substr($$
 cities-row = print "\"" $$2 "\"," $$1 "," $$3 "," $$4 ", ," $$5 "," $$6 "," $$7 "," $$8 "," $$9 "," $$10
 counties-row = print "\"" $$2 "\"," $$1 "," $$3 "," substr($$4, 2) ",\"" substr($$5, 2) "," $$6 "," $$7 "," $$8 "," $$9 "," $$10 "," $$11
 states-row = print "\"" $$2 "\"," $$1 "," $$3 "," $$4 ",USA," $$5 "," $$6 "," $$7 "," $$8 "," $$9 "," $$10
-zip-codes-row = print "\"000" substr($$2, 4) "\"," $$1 "," $$3 ",Zip Code " substr($$2, 4) ",Parent Unknown," $$5 "," $$6 "," $$7 "," $$8 "," $$9 "," $$10
+zip-codes-row = print "\"" substr($$2, 4) "\"," $$1 "," $$3 ",Zip Code " substr($$2, 4) ",Parent Unknown," $$5 "," $$6 "," $$7 "," $$8 "," $$9 "," $$10
 
 years = 2000 2010
 geo_types = states counties zip-codes cities tracts block-groups

--- a/Makefile
+++ b/Makefile
@@ -18,17 +18,15 @@ counties-row = print "\"" $$2 "\"," $$1 "," $$3 "," substr($$4, 2) ",\"" substr(
 states-row = print "\"" $$2 "\"," $$1 "," $$3 "," $$4 ",USA," $$5 "," $$6 "," $$7 "," $$8 "," $$9 "," $$10
 zip-codes-row = print "\"" substr($$2, 4) "\"," $$1 "," $$3 ",Zip Code " substr($$2, 4) ",Parent Unknown," $$5 "," $$6 "," $$7 "," $$8 "," $$9 "," $$10
 
-years = 2000 2010
 geo_types = states counties zip-codes cities tracts block-groups
-geo_years = $(foreach y,$(years),$(foreach g,$(geo_types),$g-$y))
 
 # Don't delete files created throughout on completion
 .PRECIOUS: tilesets/%.mbtiles json/united-states-geo-names.json grouped_data/united-states.csv data_tiles/%.mbtiles census/%.geojson
 # Delete files that are intermediate dependencies, not final products
 .INTERMEDIATE: data/%.csv tiles/%.mbtiles centers/%.geojson grouped_data/%.csv
-.PHONY: all clean deploy testing
+.PHONY: all clean deploy
 
-all: json/united-states-geo-names.json $(foreach t, $(geo_years), data_tiles/$(t).mbtiles)
+all: json/united-states-geo-names.json $(foreach t, $(geo_types), data_tiles/$(t).mbtiles)
 
 clean:
 	rm -rf centers data grouped_data data_tiles json tiles tilesets
@@ -38,22 +36,20 @@ submit_job:
 	aws batch submit-job --job-name etl-job --job-definition eviction-lab-etl-job --job-queue eviction-lab-etl-job-queue
 
 ## Create directories with .pbf file tiles for deployment to S3
-deploy: $(foreach t, $(geo_years), data_tiles/$(t).mbtiles)
+deploy: $(foreach t, $(geo_types), data_tiles/$(t).mbtiles)
 	mkdir -p tilesets
-	for f in $(geo_years); do tile-join --no-tile-size-limit --force -e ./tilesets/evictions-$$f ./data_tiles/$$f.mbtiles; done
+	for f in $(geo_types); do tile-join --no-tile-size-limit --force -e ./tilesets/evictions-$$f ./data_tiles/$$f.mbtiles; done
 	aws s3 cp ./tilesets s3://eviction-lab-tilesets --recursive --acl=public-read --content-encoding=gzip --region=us-east-2
 
 ## Join polygon tiles to data
-## Secondary expansion allows processing of source so that states-2010.csv comes from states.csv
-.SECONDEXPANSION:
-data_tiles/%.mbtiles: grouped_data/$$(subst -$$(lastword $$(subst -, ,$$*)),,$$*).csv tiles/%.mbtiles
+data_tiles/%.mbtiles: grouped_data/%.csv tiles/%.mbtiles
 	mkdir -p data_tiles
 	tile-join --if-matched --no-tile-size-limit --force -x GEOID -o $@ -c $^
 
 ## JSON for autocomplete
 json/united-states-geo-names.json: grouped_data/united-states.csv
 	mkdir -p json
-	csvcut -c name,parent-location,population $< | csvjson > $@
+	csvcut -c name,parent-location $< | csvjson > $@
 
 ## Combined CSV data
 grouped_data/united-states.csv: $(foreach g, $(geo_types), grouped_data/$(g).csv)
@@ -64,7 +60,7 @@ grouped_data/united-states.csv: $(foreach g, $(geo_types), grouped_data/$(g).csv
 ## Group data by FIPS code with columns for {ATTR}-{YEAR}
 grouped_data/%.csv: data/%.csv
 	mkdir -p grouped_data
-	python scripts/group_census_data.py $< $@
+	cat $< | python scripts/group_census_data.py > $@
 
 ## Fetch Google Sheets data, combine into CSV files
 data/%.csv:
@@ -76,9 +72,7 @@ data/%.csv:
 ## Create tiles from all geographies
 tiles/%.mbtiles: census/%.geojson centers/%.geojson
 	mkdir -p tiles
-	$(eval year=$(lastword $(subst -, ,$*)))
-	$(eval geo=$(subst -$(year),,$*))
-	tippecanoe -L $(geo):$< -L $(geo)-centers:$(word 2,$^) $(tippecanoe_opts) -o $@
+	tippecanoe -L $*:$< -L $*-centers:$(word 2,$^) $(tippecanoe_opts) -o $@
 
 ## GeoJSON centers
 centers/%.geojson: census/%.geojson

--- a/Makefile
+++ b/Makefile
@@ -23,14 +23,14 @@ geo_types = states counties zip-codes cities tracts block-groups
 geo_years = $(foreach y,$(years),$(foreach g,$(geo_types),$g-$y))
 
 # Don't delete files created throughout on completion
-.PRECIOUS: tilesets/%.mbtiles json/united-states-geo-names.json data/united-states.csv data/%.csv census_year_data/%.csv year_data/%.csv tiles/%.mbtiles centers/%.geojson census/%.geojson
+.PRECIOUS: tilesets/%.mbtiles json/united-states-geo-names.json grouped_data/united-states.csv data_tiles/%.mbtiles grouped_data/%.csv data/%.csv tiles/%.mbtiles centers/%.geojson census/%.geojson
 
 .PHONY: all clean deploy testing
 
 all: json/united-states-geo-names.json $(foreach t, $(geo_years), data_tiles/$(t).mbtiles)
 
 clean:
-	rm -rf centers data year_data census_year_data data_tiles json tiles tilesets
+	rm -rf centers data grouped_data data_tiles json tiles tilesets
 
 ## Submit job to AWS Batch
 submit_job:
@@ -43,36 +43,27 @@ deploy: $(foreach t, $(geo_years), data_tiles/$(t).mbtiles)
 	aws s3 cp ./tilesets s3://eviction-lab-tilesets --recursive --acl=public-read --content-encoding=gzip --region=us-east-2
 
 ## Join polygon tiles to data
-data_tiles/%.mbtiles: census_year_data/%.csv tiles/%.mbtiles
+## Secondary expansion allows processing of source so that states-2010.csv comes from states.csv
+.SECONDEXPANSION:
+data_tiles/%.mbtiles: grouped_data/$$(subst -$$(lastword $$(subst -, ,$$*)),,$$*).csv tiles/%.mbtiles
 	mkdir -p data_tiles
 	tile-join --if-matched --no-tile-size-limit --force -x GEOID -o $@ -c $^
 
 ## JSON for autocomplete
-json/united-states-geo-names.json: data/united-states.csv
+json/united-states-geo-names.json: grouped_data/united-states.csv
 	mkdir -p json
 	csvcut -c name,parent-location,population $< | csvjson > $@
 
-## Create census data grouped by decennial year
-census_year_data/%.csv: year_data/%.csv
-	mkdir -p census_year_data
-	python group_census_data.py $< $@
-
-## Get data for a census decennial year
-## Secondary expansion allows processing of source so that states-2010.csv comes from states.csv
-.SECONDEXPANSION:
-year_data/%.csv: data/$$(subst -$$(lastword $$(subst -, ,$$*)),,$$*).csv
-	$(eval census_year=$(lastword $(subst -, ,$*)))
-	$(eval geo=$(subst -$(census_year),,$*))
-	mkdir -p year_data
-	csvsql --no-inference --query  \
-		"select * from \"$(geo)\" where year >= $(census_year) and year < ($(census_year)+10)" \
-		$< > $@
-
 ## Combined CSV data
-data/united-states.csv: $(foreach g, $(geo_types), data/$(g).csv)
-	mkdir -p data
-	echo "$(column-headers)" > $@
+grouped_data/united-states.csv: $(foreach g, $(geo_types), grouped_data/$(g).csv)
+	mkdir -p grouped_data
+	head -n 1 $< > $@
 	for f in $^; do perl -ne 'print if $$. != 1' $$f >> $@; done
+
+## Group data by FIPS code with columns for {ATTR}-{YEAR}
+grouped_data/%.csv: data/%.csv
+	mkdir -p grouped_data
+	python group_census_data.py $< $@
 
 ## Fetch Google Sheets data, combine into CSV files
 data/%.csv:

--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,9 @@ geo_types = states counties zip-codes cities tracts block-groups
 geo_years = $(foreach y,$(years),$(foreach g,$(geo_types),$g-$y))
 
 # Don't delete files created throughout on completion
-.PRECIOUS: tilesets/%.mbtiles json/united-states-geo-names.json grouped_data/united-states.csv data_tiles/%.mbtiles grouped_data/%.csv data/%.csv tiles/%.mbtiles centers/%.geojson census/%.geojson
-
+.PRECIOUS: tilesets/%.mbtiles json/united-states-geo-names.json grouped_data/united-states.csv data_tiles/%.mbtiles census/%.geojson
+# Delete files that are intermediate dependencies, not final products
+.INTERMEDIATE: data/%.csv tiles/%.mbtiles centers/%.geojson grouped_data/%.csv
 .PHONY: all clean deploy testing
 
 all: json/united-states-geo-names.json $(foreach t, $(geo_years), data_tiles/$(t).mbtiles)
@@ -63,7 +64,7 @@ grouped_data/united-states.csv: $(foreach g, $(geo_types), grouped_data/$(g).csv
 ## Group data by FIPS code with columns for {ATTR}-{YEAR}
 grouped_data/%.csv: data/%.csv
 	mkdir -p grouped_data
-	python group_census_data.py $< $@
+	python scripts/group_census_data.py $< $@
 
 ## Fetch Google Sheets data, combine into CSV files
 data/%.csv:

--- a/census.mk
+++ b/census.mk
@@ -1,89 +1,32 @@
-## Makefile for creating Census geography data for 1990, 2000, 2010 from source rather than S3
-census_ftp_base = ftp://ftp2.census.gov/geo/tiger/GENZ
-census_ftp_base_2010 = $(census_ftp_base)2010/
-census_ftp_base_2016 = $(census_ftp_base)2016/shp/
-# File layout for 1990, 2000 described here https://www.census.gov/geo/maps-data/data/prev_cartbndry_names.html
-census_ftp_base_pre = ftp://ftp2.census.gov/geo/tiger/PREVGENZ/
-census_ftp_base_1990 = $(census_ftp_base_pre)
-census_ftp_base_2000 = $(census_ftp_base_pre)
+## Makefile for creating Census geography data for 2010 from source rather than S3
+census_ftp_base = ftp://ftp2.census.gov/geo/tiger/GENZ2010/
 
-base-each-func = "this.properties.GEOID = this.properties.GEOID"
+block-groups-pattern = gz_*_*_150_*_500k.zip
+tracts-pattern = gz_*_*_140_*_500k.zip
+cities-pattern = gz_*_*_160_*_500k.zip
+counties-pattern = gz_*_*_050_*_500k.zip
+states-pattern = gz_*_*_040_*_500k.zip
+zip-codes-pattern = gz_*_*_860_*_500k.zip
 
-block-groups-each-2016-func = $(base-each-func)
-tracts-each-2016-func =  $(base-each-func)
-cities-each-2016-func =  $(base-each-func)
-counties-each-2016-func =  $(base-each-func)
-states-each-2016-func =  $(base-each-func)
-zip-codes-each-2016-func = "this.properties.GEOID = this.properties.GEOID10"
+block-groups-geoid = "this.properties.GEOID = this.properties.STATE + this.properties.COUNTY + this.properties.TRACT + this.properties.BLKGRP"
+tracts-geoid = "this.properties.GEOID = this.properties.STATE + this.properties.COUNTY + this.properties.TRACT"
+cities-geoid = "this.properties.GEOID = this.properties.STATE + this.properties.PLACE"
+counties-geoid = "this.properties.GEOID = this.properties.STATE + this.properties.COUNTY"
+states-geoid =  "this.properties.GEOID = this.properties.STATE"
+zip-codes-geoid = "this.properties.GEOID = this.properties.ZCTA5"
 
-block-groups-each-2010-func = $(base-each-func)
-tracts-each-2010-func =  $(base-each-func)
-cities-each-2010-func =  $(base-each-func)
-counties-each-2010-func =  $(base-each-func)
-states-each-2010-func =  $(base-each-func)
-zip-codes-each-2010-func = "this.properties.GEOID = this.properties.ZCTA5"
-
-block-groups-each-1990-func = "this.properties.GEOID = this.properties.ST + this.properties.CO + this.properties.TRACT + this.properties.BG"
-tracts-each-1990-func = "if (this.properties.TRACTSUF) { this.properties.GEOID = this.properties.ST + this.properties.CO + this.properties.TRACTBASE + this.properties.TRACTSUF; } else { this.properties.GEOID = this.properties.ST + this.properties.CO + this.properties.TRACTBASE + '00'; }"
-cities-each-1990-func = $(base-each-func)
-counties-each-1990-func = "this.properties.GEOID = this.properties.ST + this.properties.CO"
-states-each-1990-func = "this.properties.GEOID = this.properties.ST"
-
-block-groups-each-2000-func = "this.properties.GEOID = this.properties.STATE + this.properties.COUNTY + this.properties.TRACT + this.properties.BLKGROUP"
-tracts-each-2000-func = "this.properties.GEOID = this.properties.STATE + this.properties.COUNTY + this.properties.TRACT"
-cities-each-2000-func = "this.properties.GEOID = this.properties.STATE + this.properties.PLACEFP"
-counties-each-2000-func = "this.properties.GEOID = this.properties.STATE + this.properties.COUNTY"
-states-each-2000-func = "this.properties.GEOID = this.properties.STATE"
-zip-codes-each-2000-func = "this.properties.GEOID = this.properties.ZCTA"
-
-block-groups-1990-pattern = bg*_d90_shp.zip
-tracts-1990-pattern = tr*_d90_shp.zip
-cities-1990-pattern = pl*_d90_shp.zip
-counties-1990-pattern = co*_d90_shp.zip
-states-1990-pattern = st*_d90_shp.zip
-zip-codes-1990-pattern = zt*_d90_shp.zip
-
-block-groups-2000-pattern = bg*_d00_shp.zip
-tracts-2000-pattern = tr*_d00_shp.zip
-cities-2000-pattern = pl*_d00_shp.zip
-counties-2000-pattern = co*_d00_shp.zip
-states-2000-pattern = st*_d00_shp.zip
-zip-codes-2000-pattern = zt*_d00_shp.zip
-
-block-groups-2010-pattern = gz_*_*_150_*_500k.zip
-tracts-2010-pattern = gz_*_*_140_*_500k.zip
-cities-2010-pattern = gz_*_*_160_*_500k.zip
-counties-2010-pattern = gz_*_*_050_*_500k.zip
-states-2010-pattern = gz_*_*_040_*_500k.zip
-zip-codes-2010-pattern = gz_*_*_860_*_500k.zip
-
-block-groups-2016-pattern = cb_*_*_bg_500k.zip
-tracts-2016-pattern = cb_*_*_tract_500k.zip
-cities-2016-pattern = cb_*_*_place_500k.zip
-counties-2016-pattern = cb_*_us_county_500k.zip
-states-2016-pattern = cb_*_us_state_500k.zip
-zip-codes-2016-pattern = cb_*_us_zcta510_500k.zip
-
-years = 1990 2000 2010
 geo_types = states counties zip-codes cities tracts block-groups
-geo_years = $(foreach y,$(years),$(foreach g,$(geo_types),$g-$y))
 
 .PHONY: all
 
-all: $(foreach t, $(geo_years), census/$(t).geojson)
-
-## Create manual override for 1990 zip codes because not included
-census/zip-codes-1990.geojson:
-	touch census/zip-codes-1990.geojson
+all: $(foreach t, $(geo_types), census/$(t).geojson)
 
 ## Census GeoJSON
 census/%.geojson:
 	mkdir -p census/$*
-	$(eval year=$(lastword $(subst -, ,$*)))
-	$(eval geo=$(subst -$(year),,$*))
-	wget -np -nd -r -P census/$* -A '$($*-pattern)' $(census_ftp_base_$(year))
+	wget -np -nd -r -P census/$* -A '$($*-pattern)' $(census_ftp_base)
 	for f in ./census/$*/*.zip; do unzip -d ./census/$* $$f; done
 	mapshaper ./census/$*/*.shp combine-files \
-		-each $($(geo)-each-$(year)-func) \
+		-each $($*-geoid) \
 		-filter-fields GEOID \
 		-o $@ combine-layers format=geojson

--- a/scripts/group_census_data.py
+++ b/scripts/group_census_data.py
@@ -15,7 +15,7 @@ if __name__ == '__main__':
         year_cols = ['{}-{}'.format(col, year) for col in DATA_COLS]
         year_data_cols.extend(['{}-{}'.format(col, year) for col in DATA_COLS])
         input_df[year_cols] = input_df.loc[input_df['year'] == year, DATA_COLS]
-    
+
     # Group the dataframe by GEOID, and take the max (not-null in this case) value
     # for each newly-created data column
     output_df = input_df.groupby('GEOID')[CONTEXT_COLS[1:] + year_data_cols].max()

--- a/scripts/group_census_data.py
+++ b/scripts/group_census_data.py
@@ -8,7 +8,7 @@ DATA_COLS = [
 ]
 
 if __name__ == '__main__':
-    input_df = pd.read_csv(sys.argv[1], dtype={'GEOID': 'object'})
+    input_df = pd.read_csv(sys.stdin, dtype={'GEOID': 'object'})
     year_data_cols = []
     # Append -YEAR to each data column name
     for year in input_df['year'].unique():
@@ -20,4 +20,4 @@ if __name__ == '__main__':
     # for each newly-created data column
     output_df = input_df.groupby('GEOID')[CONTEXT_COLS[1:] + year_data_cols].max()
     output_df = pd.DataFrame(output_df).reset_index()
-    output_df.to_csv(sys.argv[2], index=False)
+    output_df.to_csv(sys.stdout, index=False)


### PR DESCRIPTION
Because tile attributes may be used for charting, it seems like we would want to make them have access to all data years available for a given geography. An example would be if someone clicks on a county in 2010, we would want to create a line chart for that county's entire history, rather than just 2010-present or pull it from a separate source.

It adds some data, but I think that's negligible compared to the geography or having to store that data somewhere else. Merging into the `aws-batch-job` branch for now because that one would break some current styles, but seems like a given