### PR TITLE
Update data for predictive search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,6 @@ json
 tiles
 tilesets
 grouped_data
+search
 .vscode
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
 census
 centers
 data
-data_tiles
+census_data
+centers_data
 json
 tiles
 tilesets

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,11 @@ FROM laneolson/tippecanoe
 RUN apt-get update \
   && apt-get -y upgrade \
   && apt-get -y install build-essential libssl-dev \
-    python-pip git gzip curl wget
+    python3-dev python3-pip git gzip curl wget
 
-# Install Python packages
-RUN pip install pandas csvkit awscli
+# Link Python path, install Python packages
+RUN ln -s /usr/bin/python3 /usr/bin/python && \
+    pip3 install pandas csvkit awscli
 # Symlink NodeJS and install NPM packages
 RUN curl -sL https://deb.nodesource.com/setup_7.x | bash - && \
     ln -s /usr/bin/nodejs /usr/bin/node && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN pip install pandas csvkit awscli
 RUN curl -sL https://deb.nodesource.com/setup_7.x | bash - && \
     ln -s /usr/bin/nodejs /usr/bin/node && \
     apt-get -y install nodejs && \
-    npm install -g mapshaper geojson-polygon-labels
+    npm install -g mapshaper geojson-polygon-labels csvtojson
 
 WORKDIR /
 RUN git clone https://github.com/EvictionLab/eviction-lab-etl.git

--- a/Makefile
+++ b/Makefile
@@ -2,36 +2,72 @@ s3_base = https://s3.amazonaws.com/eviction-lab-data/
 tippecanoe_opts = --detect-shared-borders --no-feature-limit --no-tile-size-limit --no-tiny-polygon-reduction --simplification=10 -B 2 --minimum-zoom=2 --maximum-zoom=10 --force
 geo_types = states counties zip-codes cities tracts block-groups
 
+# For comma-delimited list
+null :=
+space := $(null) $(null)
+comma := ,
+
 # Don't delete files created throughout on completion
-.PRECIOUS: tilesets/%.mbtiles json/united-states-geo-names.json grouped_data/united-states.csv data_tiles/%.mbtiles census/%.geojson
+.PRECIOUS: tilesets/%.mbtiles json/united-states-search.json tiles/%.mbtiles census/%.geojson
 # Delete files that are intermediate dependencies, not final products
-.INTERMEDIATE: data/%.xlsx data/%.csv tiles/%.mbtiles centers/%.geojson grouped_data/%.csv
+.INTERMEDIATE: data/%.xlsx data/%.csv centers/%.geojson grouped_data/%.csv
 .PHONY: all clean deploy
 
-all: json/united-states-geo-names.json $(foreach t, $(geo_types), data_tiles/$(t).mbtiles)
+all: json/united-states-search.json $(foreach t, $(geo_types), tiles/$(t).mbtiles)
 
 clean:
-	rm -rf centers data grouped_data data_tiles json tiles tilesets
+	rm -rf centers data grouped_data census_data centers_data json tiles tilesets
 
 ## Submit job to AWS Batch
 submit_job:
 	aws batch submit-job --job-name etl-job --job-definition eviction-lab-etl-job --job-queue eviction-lab-etl-job-queue
 
 ## Create directories with .pbf file tiles for deployment to S3
-deploy: $(foreach t, $(geo_types), data_tiles/$(t).mbtiles)
+deploy: json/united-states-search.json $(foreach t, $(geo_types), tiles/$(t).mbtiles)
 	mkdir -p tilesets
-	for f in $(geo_types); do tile-join --no-tile-size-limit --force -e ./tilesets/evictions-$$f ./data_tiles/$$f.mbtiles; done
+	for f in $(geo_types); do tile-join --no-tile-size-limit --force -e ./tilesets/evictions-$$f ./tiles/$$f.mbtiles; done
 	aws s3 cp ./tilesets s3://eviction-lab-tilesets --recursive --acl=public-read --content-encoding=gzip --region=us-east-2
+	aws s3 cp $< s3://eviction-lab-tilesets/$(notdir $<) --acl=public-read --region=us-east-2
 
-## Join polygon tiles to data
-data_tiles/%.mbtiles: grouped_data/%.csv tiles/%.mbtiles
-	mkdir -p data_tiles
-	tile-join --if-matched --no-tile-size-limit --force -x GEOID -o $@ -c $^
+## Convert geography GeoJSON to .mbtiles
+tiles/%.mbtiles: census_data/%.geojson centers_data/%.geojson
+	mkdir -p tiles
+	tippecanoe -L $*:$< -L $*-centers:$(word 2,$^) $(tippecanoe_opts) -o $@
 
-## JSON for autocomplete
-json/united-states-geo-names.json: grouped_data/united-states.csv
+## Join center geography to grouped data, dropping attributes that don't start with eviction-rate-
+centers_data/%.geojson: grouped_data/%.csv centers/%.geojson
+	mkdir -p centers_data
+	mapshaper -i $(word 2,$^) field-types=GEOID:str -join $< field-types=GEOID:str keys=GEOID,GEOID \
+		-filter "this.properties.name != undefined" \
+		-filter-fields $(subst $(space),$(comma),$(filter eviction-rate-%,$(subst $(comma),$(space),$(shell head -n 1 $<)))) \
+		-o $@
+
+## Join census geography to grouped data, add bbox property
+census_data/%.geojson: grouped_data/%.csv census/%.geojson
+	mkdir -p census_data
+	mapshaper -i $(word 2,$^) field-types=GEOID:str \
+		-join $< field-types=GEOID:str keys=GEOID,GEOID \
+		-filter "this.properties.name != undefined" \
+		-each "this.properties.west = this.bounds[0]; this.properties.south = this.bounds[1]; this.properties.east = this.bounds[2]; this.properties.north = this.bounds[3];" \
+		-o $@
+
+## JSON for autocomplete, pulls latest population data
+json/united-states-search.json: grouped_data/united-states.csv grouped_data/united-states-centers.csv
+	$(eval pop_col=$(lastword $(sort $(filter population-%,$(subst $(comma),$(space),$(shell head -n 1 $<))))))
+	csvjoin -c GEOID $^ | \
+		csvcut -c GEOID,name,parent-location,$(pop_col),layer,longitude,latitude | \
+		csvgrep -c layer -r "(states|counties|zip-codes|cities)" | \
+		csvjson > $@
+
+## Convert the united-states-centers.geojson to CSV for merge later
+grouped_data/united-states-centers.csv: json/united-states-centers.geojson
+	in2csv --format geojson $< | csvcut -c GEOID,layer,longitude,latitude > $@
+
+## Create combined GeoJSON file with all center points, layer added as property
+json/united-states-centers.geojson: $(foreach g, $(geo_types), centers/$(g).geojson)
 	mkdir -p json
-	csvcut -c name,parent-location $< | csvjson > $@
+	for g in $(geo_types); do mapshaper -i centers/$$g.geojson -each "this.properties.layer = \"$$g\"" -o centers/$$g.geojson format=geojson force; done
+	mapshaper -i $^ combine-files -merge-layers -o $@ format=geojson
 
 ## Combined CSV data
 grouped_data/united-states.csv: $(foreach g, $(geo_types), grouped_data/$(g).csv)
@@ -52,11 +88,6 @@ data/%.csv: data/%.xlsx
 data/%.xlsx:
 	mkdir -p data
 	wget -P data $(s3_base)$@
-
-## Create tiles from all geographies
-tiles/%.mbtiles: census/%.geojson centers/%.geojson
-	mkdir -p tiles
-	tippecanoe -L $*:$< -L $*-centers:$(word 2,$^) $(tippecanoe_opts) -o $@
 
 ## GeoJSON centers
 centers/%.geojson: census/%.geojson

--- a/Makefile
+++ b/Makefile
@@ -54,10 +54,10 @@ census_data/%.geojson: grouped_data/%.csv census/%.geojson
 ## JSON for autocomplete, pulls latest population data
 json/united-states-search.json: grouped_data/united-states.csv grouped_data/united-states-centers.csv
 	$(eval pop_col=$(lastword $(sort $(filter population-%,$(subst $(comma),$(space),$(shell head -n 1 $<))))))
-	csvjoin -c GEOID $^ | \
+	csvjoin -I -c GEOID $^ | \
 		csvcut -c GEOID,name,parent-location,$(pop_col),layer,longitude,latitude | \
 		csvgrep -c layer -r "(states|counties|zip-codes|cities)" | \
-		csvjson > $@
+		csvtojson --colParser='{"GEOID":"string", "$(pop_col)": "number", "longitude": "number", "latitude": "number"}' > $@
 
 ## Convert the united-states-centers.geojson to CSV for merge later
 grouped_data/united-states-centers.csv: json/united-states-centers.geojson

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Makefile for running ETL on Eviction Lab data.
 
 ## Setup
 
-You'll need Node, Python, GNU Make, and `wget` installed. You'll also need the Python packages `pandas` and [`csvkit`](https://csvkit.readthedocs.io/en/1.0.2/index.html) and the NPM packages [`mapshaper`](https://github.com/mbloch/mapshaper) and [`geojson-polygon-labels`](https://github.com/andrewharvey/geojson-polygon-labels) as well as [`tippecanoe`](https://github.com/mapbox/tippecanoe). To install these dependencies (on Mac) run:
+You'll need Node, Python, GNU Make, and `wget` installed. You'll also need the Python packages `pandas` and [`csvkit`](https://csvkit.readthedocs.io/en/1.0.2/index.html) and the NPM packages [`mapshaper`](https://github.com/mbloch/mapshaper), `csvtojson`, and [`geojson-polygon-labels`](https://github.com/andrewharvey/geojson-polygon-labels) as well as [`tippecanoe`](https://github.com/mapbox/tippecanoe). To install these dependencies (on Mac) run:
 
 ```bash
 npm install -g mapshaper geojson-polygon-labels

--- a/scripts/create_search_index.py
+++ b/scripts/create_search_index.py
@@ -1,0 +1,26 @@
+import os
+import sys
+import pandas as pd
+
+if __name__ == '__main__':
+    us_data_df = pd.read_csv(sys.argv[1], dtype={'GEOID': 'object'})
+    us_center_df = pd.read_csv(sys.argv[2], dtype={'GEOID': 'object'})
+    us_df = us_data_df.merge(us_center_df, on='GEOID')
+
+    pop_col = sorted([c for c in us_df.columns.values.tolist() if c.startswith('population-')])[-1]
+    us_df = us_df.loc[
+        us_df['layer'].isin(['states', 'counties', 'zip-codes', 'cities']),
+        ['GEOID', 'name', 'parent-location', pop_col, 'layer', 'longitude', 'latitude']
+    ].copy()
+
+    # Write full JSON file
+    us_df.to_json(sys.argv[3], orient='records')
+
+    first_chars = set([n[0] for n in us_df['name'].str.lower().tolist()])
+    first_two_chars = set([n[:2] for n in us_df['name'].str.lower().tolist()])
+
+    # Iterate through lower-cased first two characters, create file based off of each
+    for c in first_chars.union(first_two_chars):
+        c_path = os.path.join(sys.argv[4], '{}.json'.format(c))
+        us_df['lower_name'] = us_df['name'].str.lower()
+        us_df.loc[us_df['name'].str.startswith(c)].to_json(c_path, orient='records')


### PR DESCRIPTION
Closes #12 and #13. Based on issues in this repo and eviction-maps, added the bounding box coordinates for each polygon (as directions because arrays not supported in vector tiles), removed extra properties in the center tiles to reduce size, and creating united-states-search.json which has the properties necessary for querying vector tile data and displaying search without excessive file size.