### PR TITLE
Split data by decennial census

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ json
 tiles
 tilesets
 grouped_data
+year_data
 search
 fixtures
 .vscode

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ geo_years = $(foreach y,$(years),$(foreach g,$(geo_types),$g-$y))
 states_min_zoom = 2
 counties_min_zoom = 2
 cities_min_zoom = 4
-zip-codes_min_zoom = 5
+zip-codes_min_zoom = 6
 tracts_min_zoom = 6
 block-groups_min_zoom = 7
 

--- a/Makefile
+++ b/Makefile
@@ -120,7 +120,7 @@ year_data/%.csv: grouped_data/$$(subst -$$(lastword $$(subst -, ,$$*)),,$$*).csv
 ## Group data by FIPS code with columns for {ATTR}-{YEAR}
 grouped_data/%.csv: data/%.csv
 	mkdir -p grouped_data
-	cat $< | python scripts/group_census_data.py > $@
+	cat $< | python3 scripts/group_census_data.py > $@
 
 ## Fetch Excel data, combine into CSV files
 data/%.csv: data/%.xlsx

--- a/Makefile
+++ b/Makefile
@@ -16,10 +16,10 @@ block-groups_min_zoom = 7
 
 states_bytes = 1000000
 counties_bytes = 5000000
-cities_bytes = 75000
-zip-codes_bytes = 75000
-tracts_bytes = 75000
-block-groups_bytes = 75000
+cities_bytes = 200000
+zip-codes_bytes = 200000
+tracts_bytes = 200000
+block-groups_bytes = 200000
 
 census_opts = --detect-shared-borders --coalesce-smallest-as-needed
 small_tile_census_opts = --low-detail=10 --grid-low-zooms $(census_opts)
@@ -38,9 +38,7 @@ space := $(null) $(null)
 comma := ,
 
 # Don't delete files created throughout on completion
-.PRECIOUS: tilesets/%.mbtiles tiles/%.mbtiles census/%.geojson
-# Delete files that are intermediate dependencies, not final products
-.INTERMEDIATE: data/%.xlsx data/%.csv centers/%.geojson grouped_data/%.csv
+.PRECIOUS: tilesets/%.mbtiles tiles/%.mbtiles census/%.geojson census/%.mbtiles centers/%.mbtiles
 .PHONY: all clean deploy
 
 all: $(foreach t, $(geo_years), tiles/$(t).mbtiles)

--- a/scripts/create_fake_data.py
+++ b/scripts/create_fake_data.py
@@ -1,5 +1,6 @@
 import sys
 import random
+import numpy as np
 import pandas as pd
 
 YEARS = list(range(1990, 2018))
@@ -31,7 +32,7 @@ if __name__ == '__main__':
         context_df[col] = context_df['GEOID'].apply(lambda x: random.randrange(*value))
     for col, value in sample_dict.items():
         context_df[col] = context_df['GEOID'].apply(lambda x: random.choice(value))
-    context_df['eviction-rate'] = context_df['evictions'] / context_df['renting-occupied-households']
+    context_df['eviction-rate'] = context_df['evictions'] / (context_df['renting-occupied-households'] / 100)
     context_df['eviction-rate'] = context_df['eviction-rate'].round(2)
 
     year_df_list = [context_df]
@@ -44,4 +45,5 @@ if __name__ == '__main__':
         year_df_list.append(year_df)
 
     output_df = pd.concat(year_df_list).round(2)
+    output_df.replace(np.inf, 0, inplace=True)
     output_df.to_csv(sys.stdout, index=False)

--- a/scripts/create_fake_data.py
+++ b/scripts/create_fake_data.py
@@ -2,7 +2,7 @@ import sys
 import random
 import pandas as pd
 
-YEARS = list(range(2001, 2010))
+YEARS = list(range(1990, 2018))
 
 DATA_COLS = {
     'evictions-per-day': (0, 1000),

--- a/scripts/group_census_data.py
+++ b/scripts/group_census_data.py
@@ -12,6 +12,7 @@ if __name__ == '__main__':
         col_map = json.load(col_f)
     input_df = pd.read_csv(sys.stdin, dtype={'GEOID': 'object', 'name': 'object'}).round(2)
     input_df.rename(columns=col_map, inplace=True)
+    input_df['n'] = input_df['n'].apply(lambda x: '{}'.format(x))
     # Get non-context or year columns
     data_cols = [c for c in input_df.columns.values if c not in CONTEXT_COLS + ['year']]
 

--- a/scripts/group_census_data.py
+++ b/scripts/group_census_data.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import csv
 import json
 import pandas as pd
 from functools import reduce
@@ -12,7 +13,6 @@ if __name__ == '__main__':
         col_map = json.load(col_f)
     input_df = pd.read_csv(sys.stdin, dtype={'GEOID': 'object', 'name': 'object'}).round(2)
     input_df.rename(columns=col_map, inplace=True)
-    input_df['n'] = input_df['n'].apply(lambda x: '{}'.format(x))
     # Get non-context or year columns
     data_cols = [c for c in input_df.columns.values if c not in CONTEXT_COLS + ['year']]
 
@@ -32,4 +32,4 @@ if __name__ == '__main__':
 
     # Join all year dataframes together with context on GEOID index
     output_df = reduce(lambda x, y: x.join(y, how='left'), [context_df] + year_df_list)
-    output_df[~output_df.index.duplicated()].to_csv(sys.stdout)
+    output_df[~output_df.index.duplicated()].to_csv(sys.stdout, quoting=csv.QUOTE_NONNUMERIC)

--- a/scripts/group_census_data.py
+++ b/scripts/group_census_data.py
@@ -31,4 +31,4 @@ if __name__ == '__main__':
 
     # Join all year dataframes together with context on GEOID index
     output_df = reduce(lambda x, y: x.join(y, how='left'), [context_df] + year_df_list)
-    output_df.to_csv(sys.stdout)
+    output_df[~output_df.index.duplicated()].to_csv(sys.stdout)

--- a/scripts/subset_cols.py
+++ b/scripts/subset_cols.py
@@ -1,0 +1,12 @@
+import re
+import csv
+import sys
+import pandas as pd
+
+
+if __name__ == '__main__':
+    input_df = pd.read_csv(sys.stdin, dtype={'GEOID': 'object', 'n': 'object'})
+    output_cols = sys.argv[1].split(',')
+    input_df[output_cols].to_csv(
+        sys.stdout, index=False, quoting=csv.QUOTE_NONNUMERIC
+    )

--- a/search.mk
+++ b/search.mk
@@ -9,7 +9,7 @@ clean_search: rm -rf json search grouped_data/united-states*.csv
 ## General search file, and search index files from first or first two characters of name
 json/united-states-search.json: grouped_data/united-states.csv grouped_data/united-states-centers.csv
 	mkdir -p search
-	python scripts/create_search_index.py $^ $@ search
+	python3 scripts/create_search_index.py $^ $@ search
 
 ## Convert the united-states-centers.geojson to CSV for merge later
 grouped_data/united-states-centers.csv: json/united-states-centers.geojson


### PR DESCRIPTION
Closes #23, and #27. Data is now grouped into tile layers by decennial census, but all layers have the same name (ie `zip-codes`, `zip-codes-centers`) to minimize the properties that need to be changed for the map.

Also fixes some issues with the seed data and floating point numbers not being rounded (excluding coordinates)