### PR TITLE
Setup dependent jobs in AWS Batch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,5 @@ branches:
   - master
 sudo: required
 before_install:
-- sudo pip install awscli
+- sudo pip install awscli boto3
 script: 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then make submit_jobs; fi'

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ comma := ,
 
 # Don't delete files created throughout on completion
 .PRECIOUS: tilesets/%.mbtiles tiles/%.mbtiles census/%.geojson census/%.mbtiles centers/%.mbtiles
-.PHONY: all clean deploy
+.PHONY: all clean deploy submit_jobs
 
 all: $(output_tiles)
 

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,8 @@ counties_census_opts = --minimum-zoom=$(counties_min_zoom) $(census_opts) --maxi
 
 mapshaper_cmd = node --max_old_space_size=4096 $$(which mapshaper)
 
+output_tiles = $(foreach t, $(geo_years), tiles/$(t).mbtiles)
+
 # For comma-delimited list
 null :=
 space := $(null) $(null)
@@ -41,14 +43,14 @@ comma := ,
 .PRECIOUS: tilesets/%.mbtiles tiles/%.mbtiles census/%.geojson census/%.mbtiles centers/%.mbtiles
 .PHONY: all clean deploy
 
-all: $(foreach t, $(geo_years), tiles/$(t).mbtiles)
+all: $(output_tiles)
 
 clean:
 	rm -rf centers data grouped_data year_data census_data centers_data json tiles tilesets
 
-## Submit job to AWS Batch
+## Submit jobs to AWS Batch
 submit_jobs:
-	for g in $(geo_years); do aws batch submit-job --job-name etl-job --job-definition eviction-lab-etl-job --job-queue eviction-lab-etl-job-queue --parameters filename=tiles/$$g.mbtiles; done
+	python3 scripts/submit_jobs.py $(output_tiles)
 
 ## Create directories with .pbf file tiles for deployment to S3
 deploy:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Makefile for running ETL on Eviction Lab data.
 
 ## Setup
 
-You'll need Node, Python, GNU Make, and `wget` installed. You'll also need the Python packages `pandas` and [`csvkit`](https://csvkit.readthedocs.io/en/1.0.2/index.html) and the NPM packages [`mapshaper`](https://github.com/mbloch/mapshaper), and [`geojson-polygon-labels`](https://github.com/andrewharvey/geojson-polygon-labels) as well as [`tippecanoe`](https://github.com/mapbox/tippecanoe). To install these dependencies (on Mac) run:
+You'll need Node, Python, GNU Make, and `wget` installed. You'll also need the Python packages `pandas`, `boto3`, and [`csvkit`](https://csvkit.readthedocs.io/en/1.0.2/index.html) and the NPM packages [`mapshaper`](https://github.com/mbloch/mapshaper), and [`geojson-polygon-labels`](https://github.com/andrewharvey/geojson-polygon-labels) as well as [`tippecanoe`](https://github.com/mapbox/tippecanoe). To install these dependencies (on Mac) run:
 
 ```bash
 npm install -g mapshaper geojson-polygon-labels

--- a/scripts/submit_jobs.py
+++ b/scripts/submit_jobs.py
@@ -1,0 +1,25 @@
+import sys
+import boto3
+
+
+if __name__ == '__main__':
+    client = boto3.client('batch')
+
+    job_filenames = sys.argv[1:]
+    batch_jobs = []
+    for filename in job_filenames:
+        job_kwargs = {
+            'jobName': 'etl-job',
+            'jobQueue': 'eviction-lab-etl-job-queue',
+            'jobDefinition': 'eviction-lab-etl-job',
+            'retryStrategy': {
+                'attempts': 3
+            },
+            'parameters': {
+                'filename': filename
+            }
+        }
+        if len(batch_jobs):
+            job_kwargs['dependsOn'] = [{'jobId': batch_jobs[-1]['jobId']}]
+        res = client.submit_job(**job_kwargs)
+        batch_jobs.append(res)


### PR DESCRIPTION
Use Python script for AWS Batch deployment, set up each job as dependent on the previous job and also add 3 retries each. Avoiding errors with resource allocation when all jobs are queued at the same time.