### PR TITLE
Remove eviction data from non-center features

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -148,11 +148,12 @@ centers_data/%.csv: grouped_data/%.csv
 	python3 utils/subset_cols.py $($*_center_cols),$(subst $(space),$(comma),$(filter e%,$(subst $(comma),$(space),$(shell head -n 1 $<)))) | \
 	perl -ne 'if ($$. == 1) { s/"//g; } print;' > $@
 
-## census_data/%.mbtiles            : Create census shape tiles from joining data and geography tiles
+## census_data/%.mbtiles            : Create census shape tiles from joining non-eviction data and geography tiles
 .SECONDEXPANSION:
 census_data/%.mbtiles: grouped_data/%.csv census/$$(subst -$$(lastword $$(subst -, ,$$*)),,$$*).mbtiles
 	mkdir -p census_data
-	tile-join -l $(subst -$(lastword $(subst -, ,$*)),,$*) --if-matched $(tile_join_opts) -o $@ -c $^
+	$(eval exclude_cols=$(foreach c, $(filter e%,$(subst $(comma),$(space),$(shell head -n 1 $<))), -x $c))
+	tile-join -l $(subst -$(lastword $(subst -, ,$*)),,$*) --if-matched $(tile_join_opts) $(exclude_cols) -o $@ -c $^
 
 ### GEOGRAPHY 
 

--- a/demographics.mk
+++ b/demographics.mk
@@ -39,24 +39,24 @@ data/demographics/msa.csv: data/demographics/years/msa-10.csv
 
 ## data/demographics/years/%.csv               : Create demographic data grouped by geography and year
 data/demographics/years/%.csv:
-	mkdir -p data/demographics/years
+	mkdir -p $(dir $@)
 	python3 scripts/create_data_demographics.py $* > $@
 
 ## data/demographics/years/tracts-00.csv       : Create tracts-00 demographics, convert with weights
 data/demographics/years/tracts-00.csv: census/00/tracts-weights.csv
-	mkdir -p data/demographics/years
+	mkdir -p $(dir $@)
 	python3 scripts/create_data_demographics.py tracts-00 > $@
 	python3 scripts/convert_00_geo.py tracts $@ $<
 
 ## data/demographics/years/block-groups-00.csv : Create block-groups-00 demographics, convert with weights
 data/demographics/years/block-groups-00.csv: census/00/block-groups-weights.csv census/00/block-groups.csv
-	mkdir -p data/demographics/years
+	mkdir -p $(dir $@)
 	python3 scripts/create_data_demographics.py block-groups-00 > $@
 	python3 scripts/convert_00_geo.py block-groups $@ $<
 
 ## data/demographics/years/block-groups-10.csv : Create block-groups-10 demographics
 data/demographics/years/block-groups-10.csv: census/10/block-groups.csv
-	mkdir -p data/demographics/years
+	mkdir -p $(dir $@)
 	python3 scripts/create_data_demographics.py block-groups-10 > $@
 
 ## census/%/block-groups.csv                   : Consolidate block groups by county


### PR DESCRIPTION
Dependent on https://github.com/EvictionLab/eviction-maps/pull/785

Removes eviction data from the census shape layers so that it's not duplicated with the centers layer, reducing the overall tile size