### PR TITLE
Block Group Changes

### DIFF
--- a/demographics.mk
+++ b/demographics.mk
@@ -22,7 +22,7 @@ all: $(output_files)
 ## clean                                       : Remove created demographics files
 clean:
 	rm -rf data/demographics
-	rm -rf log/
+	rm -rf log/*.txt
 
 # Based on https://swcarpentry.github.io/make-novice/08-self-doc/
 ## help                                        : Print help

--- a/scripts/utils_census.py
+++ b/scripts/utils_census.py
@@ -221,7 +221,7 @@ class CensusDataStore:
                     return getattr(c, source).get(items, lookup_dict)
             except:
                 exctype, value = sys.exc_info()[:2]
-                logger.info('received ' + str(exctype) + ' fetching ' + str(year) + ' ' + source + ' data ' + str(lookup_dict) + ', will retry shortly')
+                logger.debug('received ' + str(exctype.__name__) + ' fetching ' + str(year) + ' ' + source + ' data ' + str(lookup_dict) + ', will retry shortly')
                 logger.debug(value)
                 time.sleep(180)
             else:

--- a/scripts/utils_census.py
+++ b/scripts/utils_census.py
@@ -93,6 +93,7 @@ def get_block_group_crosswalk_df(filename):
         os.path.join(conf_dir, filename),
         dtype={
                 'cofips': 'object',
+                'bkg00': 'object',
                 'bkg09': 'object',
                 'bkg10': 'object'
             }
@@ -381,7 +382,7 @@ class CensusDataStore:
         # `convert_00_geo.py` is run using the a weight of 1
         acs_09_00_cw_df = self.getCountyBlockGroupCrosswalk('acs_09_00', county)
         if not acs_09_00_cw_df.empty:
-            acs_df = changeBlockGroupsInCensusData(acs_df, acs_09_00_cw_df, 'bg09', 'bg00')
+            acs_df = changeBlockGroupsInCensusData(acs_df, acs_09_00_cw_df, 'bkg09', 'bkg00')
         return postProcessData2000(census_sf1_df, census_sf3_df, acs_df, 'block-groups')
     
     def fetchAllBlockGroupData2010(self, county):

--- a/scripts/utils_census.py
+++ b/scripts/utils_census.py
@@ -360,9 +360,6 @@ class CensusDataStore:
             'for': 'tract:*', 
             'in': 'county:' + county[2:] + ' state:' + county[0:2] 
         }
-        # NOTE: need to double check this is an appropriate way to get all of the tracts in
-        #   a county.  It is querying ACS5, but does that have all of the tracts in
-        #   SF1, SF3, and ACS?
         tract_fips = [ r for r in self.fetchResults(source, ('NAME'), lookup_dict, year=year) ]
         for f in tract_fips:
             tract = f['state'] + f['county'] + f['tract']


### PR DESCRIPTION
  - Adjusts logs to output to file instead of task in `demograhics.mk`
  - Adjusts block groups fetching method for year 2000 by looping through tracts in each county to get the block groups
  - Fixes the column name in the block group crosswalk, and makes sure `bkg00` is an object field.